### PR TITLE
Configuration flow and set up from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@ This integration shows how you can use an ICS-2000 in Home Assistant.
 * Install HACS in Home Assistant using instructions found at https://hacs.xyz/docs/setup/download/
 * Add a custom _integration_ repository in HACS with url https://github.com/rdegraafwhizzkit/ics2000-hass
 * Select this custom repository in HACS and click 'DOWNLOAD'
+
+### Confguration
+
+#### From UI
+* Go to Settings > Devices and services and click 'Add integration' and search for **KlikAanKlikUit ICS2000**
+
+#### Via YAML
 * Add the File editor add on in Home Assistant. Using File editor, add the following entry in your `<config_dir>/configuration.yaml`:
 
 ```yaml
-light:                                      
-  - platform: ics2000
-    mac: MAC_HERE
+ics2000:                                      
+  - mac: MAC_HERE
     email: EMAIL_HERE
     password: PASSWORD_HERE_OR_secrets.yaml
     tries: 3                              # Optional, defaults to 1
@@ -19,6 +25,7 @@ light:
 ```
 * Restart Home Assistant
 
+#### Additional configuration
 You may also add `tries` and `sleep` to the config. The ICS-2000/KAKU has no way of knowing what the
 current state of a connected device is and sometimes the command does not seem to reach the device.
 If you do not experience any failures, set tries to 1. Between tries, `sleep` seconds will be paused.

--- a/custom_components/ics2000/__init__.py
+++ b/custom_components/ics2000/__init__.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -13,10 +13,10 @@ PLATFORMS: list[Platform] = [
     Platform.LIGHT
 ]
 
-async def async_setup_entry(hass: HomeAssistant, config: ConfigType) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up KlikAanKlikUit (ICS2000) from a config entry."""
     _LOGGER.debug("Setting up KlikAanKlikUit (ICS2000) entry")
 
-    await hass.config_entries.async_forward_entry_setups(config, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/custom_components/ics2000/__init__.py
+++ b/custom_components/ics2000/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry, ConfigType, SOURCE_IMPORT
 from homeassistant.const import Platform
@@ -21,17 +22,29 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     If the user has YAML configuration for this integration, start an import
     flow so the config is migrated to a Config Entry.
     """
-    
+
     # If already configured, don't do anything
     if hass.config_entries.async_entries(DOMAIN):
         return True
 
-    conf = config.get(DOMAIN)
-    if conf is None:
-        return True
+    entries: list[dict[str, Any]] = []
 
-    # Support single dict or list of dicts in YAML
-    entries = conf if isinstance(conf, list) else [conf]
+    conf = config.get(DOMAIN)
+    if conf is not None:
+        entries.extend(conf if isinstance(conf, list) else [conf])
+
+    legacy_light_config = config.get(Platform.LIGHT)
+    if legacy_light_config is not None:
+        for platform_config in legacy_light_config:
+            if platform_config.get("platform") != DOMAIN:
+                continue
+
+            legacy_entry = {**platform_config}
+            legacy_entry.pop("platform", None)
+            entries.append(legacy_entry)
+
+    if not entries:
+        return True
 
     for entry in entries:
         hass.async_create_task(

--- a/custom_components/ics2000/__init__.py
+++ b/custom_components/ics2000/__init__.py
@@ -3,15 +3,46 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigType, SOURCE_IMPORT
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.LIGHT
 ]
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the integration from YAML config by importing to a config entry.
+
+    If the user has YAML configuration for this integration, start an import
+    flow so the config is migrated to a Config Entry.
+    """
+    
+    # If already configured, don't do anything
+    if hass.config_entries.async_entries(DOMAIN):
+        return True
+
+    conf = config.get(DOMAIN)
+    if conf is None:
+        return True
+
+    # Support single dict or list of dicts in YAML
+    entries = conf if isinstance(conf, list) else [conf]
+
+    for entry in entries:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=entry,
+            )
+        )
+
+    return True
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up KlikAanKlikUit (ICS2000) from a config entry."""

--- a/custom_components/ics2000/__init__.py
+++ b/custom_components/ics2000/__init__.py
@@ -61,6 +61,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up KlikAanKlikUit (ICS2000) from a config entry."""
     _LOGGER.debug("Setting up KlikAanKlikUit (ICS2000) entry")
 
+    if entry.source == SOURCE_IMPORT:
+        entry._supports_reconfigure = False
+        entry.clear_state_cache()
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/custom_components/ics2000/__init__.py
+++ b/custom_components/ics2000/__init__.py
@@ -1,6 +1,22 @@
-DOMAIN = "ics2000"
+""" The KlikAanKlinUit integration """
+from __future__ import annotations
 
+import logging
 
-def setup(hass, config):  # noqa
-    # hass.states.set("hello_state.world", "Paulus")
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [
+    Platform.LIGHT
+]
+
+async def async_setup_entry(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up KlikAanKlikUit (ICS2000) from a config entry."""
+    _LOGGER.debug("Setting up KlikAanKlikUit (ICS2000) entry")
+
+    await hass.config_entries.async_forward_entry_setups(config, PLATFORMS)
+
     return True

--- a/custom_components/ics2000/config_flow.py
+++ b/custom_components/ics2000/config_flow.py
@@ -105,3 +105,8 @@ class ICS2000ConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=errors
         )
+
+    async def async_step_import(self, import_config: dict[str, Any]) -> ConfigFlowResult:
+        """Handle import from YAML `configuration.yaml`."""
+
+        return await self.async_step_user(import_config)

--- a/custom_components/ics2000/config_flow.py
+++ b/custom_components/ics2000/config_flow.py
@@ -1,0 +1,37 @@
+"""Config flow for the ICS2000 integration"""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_PASSWORD, CONF_MAC, CONF_EMAIL#, CONF_IP_ADDRESS
+from homeassistant.helpers import config_validation as cv
+
+from .const import DOMAIN, CONF_SLEEP, CONF_TRIES
+
+STEP_USER_DATA_SCHEMA = vol.Schema({
+    vol.Required(CONF_MAC): cv.string,
+    vol.Required(CONF_EMAIL): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_TRIES): cv.positive_int,
+    vol.Optional(CONF_SLEEP): cv.positive_int
+    # vol.Optional(CONF_IP_ADDRESS): cv.matches_regex(r'[1-9][0-9]{0,2}(\.(0|[1-9][0-9]{0,2})){2}\.[1-9][0-9]{0,2}'),
+    # vol.Optional(CONF_AES): cv.matches_regex(r'[a-zA-Z0-9]{32}')
+})
+
+class ICS2000ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """ICS2000 config flow."""
+    # The schema version of the entries that it creates
+    # Home Assistant will call your migrate method if the version changes
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+        )

--- a/custom_components/ics2000/config_flow.py
+++ b/custom_components/ics2000/config_flow.py
@@ -27,11 +27,10 @@ class ICS2000ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     MINOR_VERSION = 1
 
     async def async_step_user(self, user_input=None):
-        if user_input is not None:
+        if user_input is None:
             return self.async_show_form(
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
 
-        return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA
-        )
+        # Optionally validate connection here before creating entry.
+        return self.async_create_entry(title=user_input[CONF_MAC], data=user_input)

--- a/custom_components/ics2000/config_flow.py
+++ b/custom_components/ics2000/config_flow.py
@@ -1,36 +1,107 @@
 """Config flow for the ICS2000 integration"""
 from __future__ import annotations
+from typing import Any
 
+from ics2000_python.Core import CoreException, Hub
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant.config_entries import _LOGGER, ConfigFlow, ConfigFlowResult, HomeAssistant
 from homeassistant.const import CONF_PASSWORD, CONF_MAC, CONF_EMAIL#, CONF_IP_ADDRESS
 from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN, CONF_SLEEP, CONF_TRIES
+from .const import DOMAIN, CONF_SLEEP, CONF_TRIES, SLEEP_DEFAULT, TRIES_DEFAULT
 
 STEP_USER_DATA_SCHEMA = vol.Schema({
     vol.Required(CONF_MAC): cv.string,
     vol.Required(CONF_EMAIL): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_TRIES): cv.positive_int,
-    vol.Optional(CONF_SLEEP): cv.positive_int
+    vol.Optional(CONF_TRIES, default=TRIES_DEFAULT): cv.positive_int,
+    vol.Optional(CONF_SLEEP, default=SLEEP_DEFAULT): cv.positive_int
     # vol.Optional(CONF_IP_ADDRESS): cv.matches_regex(r'[1-9][0-9]{0,2}(\.(0|[1-9][0-9]{0,2})){2}\.[1-9][0-9]{0,2}'),
     # vol.Optional(CONF_AES): cv.matches_regex(r'[a-zA-Z0-9]{32}')
 })
 
-class ICS2000ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+async def _validate_input(hass: HomeAssistant, data: dict[str, Any]) -> bool:
+    """Validate the user input allows us to connect to the hub."""
+
+    def _create_hub():
+        return Hub(
+            data[CONF_MAC],
+            data[CONF_EMAIL],
+            data[CONF_PASSWORD],
+        )
+
+    return await hass.async_add_executor_job(_create_hub)
+
+class ICS2000ConfigFlow(ConfigFlow, domain=DOMAIN):
     """ICS2000 config flow."""
     # The schema version of the entries that it creates
     # Home Assistant will call your migrate method if the version changes
     VERSION = 1
     MINOR_VERSION = 1
 
-    async def async_step_user(self, user_input=None):
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
-            )
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                hub = await _validate_input(self.hass, user_input)
+            except CoreException as ce:
+                _LOGGER.error(f'Error validating user input: {ce}')
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(f'kaku-{hub.mac}')
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=hub.mac, data=user_input)
 
-        # Optionally validate connection here before creating entry.
-        return self.async_create_entry(title=user_input[CONF_MAC], data=user_input)
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        errors: dict[str, str] = {}
+        reconf_entry = self._get_reconfigure_entry()
+        suggested_values = {
+            CONF_MAC: reconf_entry.data[CONF_MAC],
+            CONF_EMAIL: reconf_entry.data[CONF_EMAIL],
+            CONF_PASSWORD: reconf_entry.data[CONF_PASSWORD],
+            CONF_TRIES: reconf_entry.data.get(CONF_TRIES, TRIES_DEFAULT),
+            CONF_SLEEP: reconf_entry.data.get(CONF_SLEEP, SLEEP_DEFAULT)
+            #CONF_IP_ADDRESS: reconf_entry.data[CONF_IP_ADDRESS]
+            #CONF_AES: reconf_entry.data[CONF_AES]
+        }
+
+        if user_input:
+            try:
+                hub = await _validate_input(self.hass, data={
+                        **reconf_entry.data,
+                        **user_input,
+                    }
+                )
+            except CoreException as ce:
+                _LOGGER.error(f'Error validating user input: {ce}')
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(f'kaku-{hub.mac}')
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    reconf_entry,
+                    data_updates={
+                        CONF_MAC: user_input[CONF_MAC],
+                        CONF_EMAIL: user_input[CONF_EMAIL],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        CONF_TRIES: user_input[CONF_TRIES],
+                        CONF_SLEEP: user_input[CONF_SLEEP]
+                        #CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS]
+                        #CONF_AES: user_input[CONF_AES]
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=STEP_USER_DATA_SCHEMA,
+                suggested_values=user_input or suggested_values
+            ),
+            errors=errors
+        )

--- a/custom_components/ics2000/const.py
+++ b/custom_components/ics2000/const.py
@@ -1,0 +1,7 @@
+"""Constants for the KlikAanKlikUit (ics200) integration"""
+
+DOMAIN = "ics2000"
+
+CONF_TRIES = "tries"
+CONF_SLEEP = "sleep"
+# CONF_AES = "aes"

--- a/custom_components/ics2000/const.py
+++ b/custom_components/ics2000/const.py
@@ -5,3 +5,6 @@ DOMAIN = "ics2000"
 CONF_TRIES = "tries"
 CONF_SLEEP = "sleep"
 # CONF_AES = "aes"
+
+TRIES_DEFAULT = 1
+SLEEP_DEFAULT = 3

--- a/custom_components/ics2000/light.py
+++ b/custom_components/ics2000/light.py
@@ -54,11 +54,15 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> bool:
     """Set up KlikAanKlikUit (ICS2000) from a config entry."""
-    hub = Hub(
-        entry.data[CONF_MAC],
-        entry.data[CONF_EMAIL],
-        entry.data[CONF_PASSWORD],
-    )
+    
+    def _create_hub():
+        return Hub(
+            entry.data[CONF_MAC],
+            entry.data[CONF_EMAIL],
+            entry.data[CONF_PASSWORD],
+        )
+
+    hub = await hass.async_add_executor_job(_create_hub)
 
     if not hub.connected:
         _LOGGER.error("Could not connect to ICS2000 hub")

--- a/custom_components/ics2000/light.py
+++ b/custom_components/ics2000/light.py
@@ -84,23 +84,9 @@ def setup_platform(
         discovery_info: DiscoveryInfoType | None = None  # noqa
 ) -> None:
     """Set up the ICS2000 Light platform (YAML)."""
-    hub = Hub(
-        config[CONF_MAC],
-        config[CONF_EMAIL],
-        config[CONF_PASSWORD]
-    )
-
-    # Verify that passed in configuration works
-    if not hub.connected:
-        _LOGGER.error("Could not connect to ICS2000 hub")
-        return
-
-    # Add entities
-    add_entities(_create_entities(
-        hub.devices,
-        config.get(CONF_TRIES, TRIES_DEFAULT),
-        config.get(CONF_SLEEP, SLEEP_DEFAULT),
-    ))
+    # This method is deprecated in favor of config entries, but we still need to support it for users who have configured the integration using YAML.
+    _LOGGER.warning("Configuring ICS2000 via YAML as 'light' is deprecated and will be removed in a future release. Either configure it as 'ics2000' in your YAML or via the UI.")
+    True
 
 
 class KlikAanKlikUitAction(Enum):

--- a/custom_components/ics2000/light.py
+++ b/custom_components/ics2000/light.py
@@ -12,9 +12,10 @@ from ics2000_python.Core import Hub
 from ics2000_python.Devices import Device, Dimmer
 from enum import Enum
 
-# Import the device class from the component that you want to support
+from .const import CONF_SLEEP, CONF_TRIES
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.light import ATTR_BRIGHTNESS, PLATFORM_SCHEMA, LightEntity, ColorMode
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_MAC, CONF_EMAIL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -37,10 +38,40 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MAC): cv.string,
     vol.Required(CONF_EMAIL): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional('tries'): cv.positive_int,
-    vol.Optional('sleep'): cv.positive_int
+    vol.Optional(CONF_TRIES): cv.positive_int,
+    vol.Optional(CONF_SLEEP): cv.positive_int
 })
 
+def _create_entities(devices, tries: int, sleep: int):
+    return [
+        KlikAanKlikUitDevice(device=device, tries=int(tries), sleep=int(sleep))
+        for device in devices
+    ]
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> bool:
+    """Set up KlikAanKlikUit (ICS2000) from a config entry."""
+    hub = Hub(
+        entry.data[CONF_MAC],
+        entry.data[CONF_EMAIL],
+        entry.data[CONF_PASSWORD],
+    )
+
+    if not hub.connected:
+        _LOGGER.error("Could not connect to ICS2000 hub")
+        return False
+
+    async_add_entities(
+        _create_entities(
+            hub.devices,
+            entry.data.get(CONF_TRIES, 1),
+            entry.data.get(CONF_SLEEP, 3),
+        )
+    )
+    return True
 
 def setup_platform(
         hass: HomeAssistant,  # noqa
@@ -48,10 +79,7 @@ def setup_platform(
         add_entities: AddEntitiesCallback,
         discovery_info: DiscoveryInfoType | None = None  # noqa
 ) -> None:
-    """Set up the ICS2000 Light platform."""
-    # Assign configuration variables.
-    # The configuration check takes care they are present.
-    # Setup connection with devices/cloud
+    """Set up the ICS2000 Light platform (YAML)."""
     hub = Hub(
         config[CONF_MAC],
         config[CONF_EMAIL],
@@ -64,11 +92,11 @@ def setup_platform(
         return
 
     # Add entities
-    add_entities(KlikAanKlikUitDevice(
-        device=device,
-        tries=int(config.get('tries', 1)),
-        sleep=int(config.get('sleep', 3))
-    ) for device in hub.devices)
+    add_entities(_create_entities(
+        hub.devices,
+        config.get(CONF_TRIES, 1),
+        config.get(CONF_SLEEP, 3),
+    ))
 
 
 class KlikAanKlikUitAction(Enum):

--- a/custom_components/ics2000/light.py
+++ b/custom_components/ics2000/light.py
@@ -12,7 +12,7 @@ from ics2000_python.Core import Hub
 from ics2000_python.Devices import Device, Dimmer
 from enum import Enum
 
-from .const import CONF_SLEEP, CONF_TRIES
+from .const import CONF_SLEEP, CONF_TRIES, TRIES_DEFAULT, SLEEP_DEFAULT
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.light import ATTR_BRIGHTNESS, PLATFORM_SCHEMA, LightEntity, ColorMode
 from homeassistant.config_entries import ConfigEntry
@@ -71,8 +71,8 @@ async def async_setup_entry(
     async_add_entities(
         _create_entities(
             hub.devices,
-            entry.data.get(CONF_TRIES, 1),
-            entry.data.get(CONF_SLEEP, 3),
+            entry.data.get(CONF_TRIES, TRIES_DEFAULT),
+            entry.data.get(CONF_SLEEP, SLEEP_DEFAULT),
         )
     )
     return True
@@ -98,8 +98,8 @@ def setup_platform(
     # Add entities
     add_entities(_create_entities(
         hub.devices,
-        config.get(CONF_TRIES, 1),
-        config.get(CONF_SLEEP, 3),
+        config.get(CONF_TRIES, TRIES_DEFAULT),
+        config.get(CONF_SLEEP, SLEEP_DEFAULT),
     ))
 
 

--- a/custom_components/ics2000/manifest.json
+++ b/custom_components/ics2000/manifest.json
@@ -11,6 +11,7 @@
   ],
   "iot_class": "local_polling",
   "version": "2025.11.0-2.0.5-2",
-  "integration_type": "entity",
-  "issue_tracker": "https://github.com/rdegraafwhizzkit/ics2000-hass/issues"
+  "integration_type": "device",
+  "issue_tracker": "https://github.com/rdegraafwhizzkit/ics2000-hass/issues",
+  "config_flow": true
 }


### PR DESCRIPTION
In  (https://github.com/rdegraafwhizzkit/ics2000-hass/issues/23#issuecomment-3564622988) I stated that I would send a PR for making this integration configurable from UI.
It's been a while, but I finally got time to do it.
This PR adds support for setting up the integration via UI. When it has been setup from YAML the configuration is imported. And one can still configure it from YAML, but I would suggest using the UI 😄  